### PR TITLE
Fix a bug for color fading

### DIFF
--- a/luxafor.go
+++ b/luxafor.go
@@ -106,11 +106,11 @@ func (l *Luxafor) writeCommand(command []byte) error {
 	return err
 }
 
-// Colour sets a RGB colour for specified LED(s)
+// Colour sets an RGB colour for specified LED(s)
 func (l *Luxafor) Colour(led Led, red uint8, green uint8, blue uint8, fadeTime uint8) error {
 	data := []byte{0x01, byte(led), red, green, blue, fadeTime, 0x0, 0x0}
 	if fadeTime > 0 {
-		data[1] = 0x02
+		data[0] = 0x02
 	}
 	return l.writeCommand(data)
 }


### PR DESCRIPTION
When using a fade time longer than 0, the wrong byte is patched on the command that's being sent to the Luxafor. This makes it so that the only colour slightly changes, instead of the wanted effect of fading to a different colour.

This PR fixes that.

How to test:

* Set a Luxafor to static colour red (255, 0, 0)
* Now set the Luxafor to a static colour green (0, 255, 0) using a fade time of 30.

See that this not work correctly, but after using my patch it does.